### PR TITLE
Cleanup relationship between UTM and NWU

### DIFF
--- a/src/UTMConverter.cpp
+++ b/src/UTMConverter.cpp
@@ -91,7 +91,12 @@ base::samples::RigidBodyState UTMConverter::convertToUTM(const gps_base::Solutio
 
 base::samples::RigidBodyState UTMConverter::convertToNWU(const gps_base::Solution &solution) const
 {
-    base::samples::RigidBodyState position = convertToUTM(solution);
+    return convertToNWU(convertToUTM(solution));
+}
+
+base::samples::RigidBodyState UTMConverter::convertToNWU(const base::samples::RigidBodyState &utm) const
+{
+    base::samples::RigidBodyState position = utm;
     double easting  = position.position.x();
     double northing = position.position.y();
     position.position.x() = northing;

--- a/src/UTMConverter.cpp
+++ b/src/UTMConverter.cpp
@@ -6,11 +6,11 @@ using namespace std;
 using namespace gps_base;
 
 UTMConverter::UTMConverter()
+    : utm_zone(32)
+    , utm_north(true)
+    , origin(base::Position::Zero())
+    , coTransform(NULL)
 {
-    this->utm_zone = 32;
-    this->utm_north = true;
-    this->origin = base::Position::Zero();
-    this->coTransform = NULL;
     createCoTransform();
 }
 

--- a/src/UTMConverter.cpp
+++ b/src/UTMConverter.cpp
@@ -10,6 +10,7 @@ UTMConverter::UTMConverter()
     this->utm_zone = 32;
     this->utm_north = true;
     this->origin = base::Position::Zero();
+    this->coTransform = NULL;
     createCoTransform();
 }
 
@@ -22,12 +23,13 @@ void UTMConverter::createCoTransform()
     oTargetSRS.SetWellKnownGeogCS("WGS84");
     oTargetSRS.SetUTM(this->utm_zone, this->utm_north);
 
-    coTransform = OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
-
-    if (coTransform == NULL)
-    {
+    OGRCoordinateTransformation* newTransform =
+        OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
+    if (newTransform == NULL)
         throw runtime_error("Failed to initialize CoordinateTransform");
-    }
+
+    delete coTransform;
+    coTransform = newTransform;
 }
 
 void UTMConverter::setUtmZone(int zone)

--- a/src/UTMConverter.cpp
+++ b/src/UTMConverter.cpp
@@ -32,24 +32,24 @@ void UTMConverter::createCoTransform()
     coTransform = newTransform;
 }
 
-void UTMConverter::setUtmZone(int zone)
+void UTMConverter::setUTMZone(int zone)
 {
     this->utm_zone = zone;
     createCoTransform();
 }
 
-void UTMConverter::setUtmNorth(bool north)
+void UTMConverter::setUTMNorth(bool north)
 {
     this->utm_north = north;
     createCoTransform();
 }
 
-int UTMConverter::getUtmZone()
+int UTMConverter::getUTMZone()
 {
     return this->utm_zone;
 }
 
-bool UTMConverter::getUtmNorth()
+bool UTMConverter::getUTMNorth()
 {
     return this->utm_north;
 }

--- a/src/UTMConverter.hpp
+++ b/src/UTMConverter.hpp
@@ -21,13 +21,21 @@ namespace gps_base
         public:
             UTMConverter();
 
-            void setUtmZone(int zone);
-            void setUtmNorth(bool north);
-            int getUtmZone();
-            bool getUtmNorth();
+            /** Sets the UTM zone
+             */
+            void setUTMZone(int zone);
             void setOrigin(base::Position origin);
             base::Position getOrigin();
 
+            /** Sets the UTM zone
+             */
+            void setUTMNorth(bool north);
+            
+            /** Get the UTM zone */
+            int getUTMZone();
+
+            /** Get whether we're north or south of the equator */
+            bool getUTMNorth();
             bool convertSolutionToRBS(const gps_base::Solution &solution, base::samples::RigidBodyState &position);
     };
 

--- a/src/UTMConverter.hpp
+++ b/src/UTMConverter.hpp
@@ -24,19 +24,39 @@ namespace gps_base
             /** Sets the UTM zone
              */
             void setUTMZone(int zone);
-            void setOrigin(base::Position origin);
-            base::Position getOrigin();
 
             /** Sets the UTM zone
              */
             void setUTMNorth(bool north);
             
             /** Get the UTM zone */
-            int getUTMZone();
+            int getUTMZone() const;
 
             /** Get whether we're north or south of the equator */
-            bool getUTMNorth();
-            bool convertSolutionToRBS(const gps_base::Solution &solution, base::samples::RigidBodyState &position);
+            bool getUTMNorth() const;
+
+            /** Set a position that will be removed from the computed UTM
+             * solution
+             */
+            void setNWUOrigin(base::Position origin);
+
+            /** Returns the current origin position in UTM coordinates
+             */
+            base::Position getNWUOrigin() const;
+
+            /** Convert a GPS solution into UTM coordinates
+             *
+             * The returned RBS will has all its fields invalidated (only the
+             * timestamp updated) if there is no solution
+             */
+            base::samples::RigidBodyState convertToUTM(const gps_base::Solution &solution) const;
+
+            /** Convert a GPS solution into NWU coordinates (Rock's convention)
+             *
+             * The returned RBS will has all its fields invalidated (only the
+             * timestamp updated) if there is no solution
+             */
+            base::samples::RigidBodyState convertToNWU(const gps_base::Solution &solution) const;
     };
 
 } // end namespace gps_base

--- a/src/UTMConverter.hpp
+++ b/src/UTMConverter.hpp
@@ -57,6 +57,10 @@ namespace gps_base
              * timestamp updated) if there is no solution
              */
             base::samples::RigidBodyState convertToNWU(const gps_base::Solution &solution) const;
+
+            /** Convert a UTM-converted GPS solution into NWU coordinates (Rock's convention)
+             */
+            base::samples::RigidBodyState convertToNWU(const base::samples::RigidBodyState &solution) const;
     };
 
 } // end namespace gps_base

--- a/test/test_UTMConverter.cpp
+++ b/test/test_UTMConverter.cpp
@@ -8,60 +8,126 @@ BOOST_AUTO_TEST_CASE(it_should_not_crash_when_instantiated)
     gps_base::UTMConverter converter;
 }
 
-BOOST_AUTO_TEST_CASE(it_should_output_utm_position)
+BOOST_AUTO_TEST_CASE(it_converts_the_position)
 {
-    gps_base::UTMConverter converter;
     gps_base::Solution solution;
-    base::samples::RigidBodyState pos;
-
+    solution.positionType = gps_base::AUTONOMOUS;
     solution.latitude = -13.057361;
     solution.longitude = -38.649902;
-    solution.altitude = 0.0;
+    solution.altitude = 2.0;
+
+    gps_base::UTMConverter converter;
     converter.setUTMZone(24);
     converter.setUTMNorth(false);
+
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
+    BOOST_REQUIRE_CLOSE(pos.position.x(), 537956.57943, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.y(), 8556494.7274, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.z(), 2, 0.0001);
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE_CLOSE(pos.position.x(), 8556494.7274, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.y(), 1000000 - 537956.57943, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.z(), 2, 0.0001);
+}
+
+BOOST_AUTO_TEST_CASE(it_applies_the_origin_only_in_NWU_coordinates)
+{
+    gps_base::Solution solution;
+    solution.positionType = gps_base::AUTONOMOUS;
+    solution.latitude = -13.057361;
+    solution.longitude = -38.649902;
+    solution.altitude = 2.0;
+
+    gps_base::UTMConverter converter;
+    converter.setUTMZone(24);
+    converter.setUTMNorth(false);
+    converter.setNWUOrigin(base::Position(8550000, 400000, 0));
+
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
+    BOOST_REQUIRE_CLOSE(pos.position.x(), 537956.57943, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.y(), 8556494.7274, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.z(), 2, 0.0001);
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE_CLOSE(pos.position.x(), 6494.7274, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.y(), 62043.420570012648, 0.0001);
+    BOOST_REQUIRE_CLOSE(pos.position.z(), 2, 0.0001);
+}
+
+BOOST_AUTO_TEST_CASE(it_propagates_the_deviations)
+{
+    gps_base::Solution solution;
     solution.positionType = gps_base::AUTONOMOUS;
     solution.deviationLatitude = 0.2;
     solution.deviationLongitude = 0.33;
     solution.deviationAltitude = 0.27;
 
-    BOOST_REQUIRE_EQUAL(true, converter.convertSolutionToRBS(solution, pos));
+    gps_base::UTMConverter converter;
 
-    BOOST_REQUIRE_CLOSE(pos.position.x(), 537956.57943, 0.0001);
-    BOOST_REQUIRE_CLOSE(pos.position.y(), 8556494.7274, 0.0001);
-    BOOST_REQUIRE_CLOSE(pos.position.z(), 0, 0.0001);
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
     BOOST_REQUIRE_CLOSE(0.33*0.33, pos.cov_position(0, 0), 0.0001);
-    BOOST_REQUIRE_CLOSE(0.2*0.2, pos.cov_position(1, 1), 0.0001);
+    BOOST_REQUIRE_CLOSE(0.2*0.2,   pos.cov_position(1, 1), 0.0001);
     BOOST_REQUIRE_CLOSE(0.27*0.27, pos.cov_position(2, 2), 0.0001);
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE_CLOSE(0.2*0.2,   pos.cov_position(0, 0), 0.0001);
+    BOOST_REQUIRE_CLOSE(0.33*0.33, pos.cov_position(1, 1), 0.0001);
+    BOOST_REQUIRE_CLOSE(0.27*0.27, pos.cov_position(2, 2), 0.0001);
+}
 
-    return;
+BOOST_AUTO_TEST_CASE(it_propagates_the_timestamp)
+{
+    gps_base::Solution solution;
+    solution.time = base::Time::fromSeconds(100);
+    solution.positionType = gps_base::AUTONOMOUS;
+
+    gps_base::UTMConverter converter;
+
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
+    BOOST_REQUIRE_EQUAL(base::Time::fromSeconds(100), pos.time);
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE_EQUAL(base::Time::fromSeconds(100), pos.time);
 }
 
 BOOST_AUTO_TEST_CASE(covariance_should_be_unset_if_deviation_is_unset)
 {
-    gps_base::UTMConverter converter;
     gps_base::Solution solution;
-    base::samples::RigidBodyState pos;
-
     solution.positionType = gps_base::AUTONOMOUS;
     solution.deviationLatitude = base::unset<float>();
     solution.deviationLongitude = base::unset<float>();
     solution.deviationAltitude = base::unset<float>();
 
-    BOOST_REQUIRE_EQUAL(true, converter.convertSolutionToRBS(solution, pos));
-    BOOST_REQUIRE_EQUAL(true, base::isUnset<float>(pos.cov_position(0, 0)));
-    BOOST_REQUIRE_EQUAL(true, base::isUnset<float>(pos.cov_position(1, 1)));
-    BOOST_REQUIRE_EQUAL(true, base::isUnset<float>(pos.cov_position(2, 2)));
+    gps_base::UTMConverter converter;
+
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(0, 0)));
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(1, 1)));
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(2, 2)));
+
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(0, 0)));
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(1, 1)));
+    BOOST_REQUIRE(base::isUnset<float>(pos.cov_position(2, 2)));
 }
 
-BOOST_AUTO_TEST_CASE(it_should_return_false_if_solution_is_unset)
+BOOST_AUTO_TEST_CASE(the_convertion_methods_return_an_invalid_RBS_with_timestamp_set_if_there_is_no_solution)
 {
-    gps_base::UTMConverter converter;
     gps_base::Solution solution;
-    base::samples::RigidBodyState pos;
-
+    solution.time = base::Time::now();
     solution.positionType = gps_base::NO_SOLUTION;
-    BOOST_REQUIRE_EQUAL(false, converter.convertSolutionToRBS(solution, pos));
 
-    return;
+    gps_base::UTMConverter converter;
+
+    base::samples::RigidBodyState pos;
+    pos = converter.convertToUTM(solution);
+    BOOST_REQUIRE_EQUAL(solution.time, pos.time);
+    BOOST_REQUIRE(!pos.hasValidPosition());
+
+    pos = converter.convertToNWU(solution);
+    BOOST_REQUIRE_EQUAL(solution.time, pos.time);
+    BOOST_REQUIRE(!pos.hasValidPosition());
 }
 

--- a/test/test_UTMConverter.cpp
+++ b/test/test_UTMConverter.cpp
@@ -14,12 +14,11 @@ BOOST_AUTO_TEST_CASE(it_should_output_utm_position)
     gps_base::Solution solution;
     base::samples::RigidBodyState pos;
 
-    converter.setUtmZone(24);
-    converter.setUtmNorth(false);
-
     solution.latitude = -13.057361;
     solution.longitude = -38.649902;
     solution.altitude = 0.0;
+    converter.setUTMZone(24);
+    converter.setUTMNorth(false);
     solution.positionType = gps_base::AUTONOMOUS;
     solution.deviationLatitude = 0.2;
     solution.deviationLongitude = 0.33;


### PR DESCRIPTION
Rock is using NWU as its global reference frame, but UTM is ENU. Ideally, the new GPS implementation should offer a NWU-compatible output. This is what this PR is about.

Methods are now clearly tagged with either UTM or NWU, depending on what they do. The origin is applied only on the NWU case, since it really is the pose that should be used by the Rock system.

https://github.com/Brazilian-Institute-of-Robotics/drivers-orogen-ecomm_board/pull/8 should be applied together with it