### PR TITLE
added OMNISTAR to GPS_SOLUTION_TYPES

### DIFF
--- a/src/BaseTypes.hpp
+++ b/src/BaseTypes.hpp
@@ -14,7 +14,8 @@ namespace gps_base
         DIFFERENTIAL = 2,
         INVALID      = 3,
         RTK_FIXED    = 4,
-        RTK_FLOAT    = 5
+        RTK_FLOAT    = 5,
+        OMNISTAR     = 7
     };
 
     struct Time {

--- a/src/BaseTypes.hpp
+++ b/src/BaseTypes.hpp
@@ -8,14 +8,13 @@ namespace gps_base
 {
     enum GPS_SOLUTION_TYPES
     {
-        NO_SOLUTION  = 0,
-        AUTONOMOUS_2D  = 6, // is 6 for historical reasons
-        AUTONOMOUS   = 1,
-        DIFFERENTIAL = 2,
-        INVALID      = 3,
-        RTK_FIXED    = 4,
-        RTK_FLOAT    = 5,
-        OMNISTAR     = 7
+        NO_SOLUTION    = 0, //No GPS solution found
+        AUTONOMOUS_2D  = 6, //Like AUTONOMOUS, but solution doesn't provide height information. Is 6 for historical reasons
+        AUTONOMOUS     = 1, //No correction
+        DIFFERENTIAL   = 2, //Atmospheric correction is used e.g. as provided by a Satellite or Ground Based Augmentation System
+        INVALID        = 3, //Correction result is invalid
+        RTK_FIXED      = 4, //Complete RTK correction
+        RTK_FLOAT      = 5  //Real Time Kinematics correction with undetermined phase shift
     };
 
     struct Time {


### PR DESCRIPTION
Advanced Navigation D-GPS driver provides solution type `gnss_fix_omnistar`. This PR reflects this value by extending  `GPS_SOLUTION_TYPE` with the value `OMNISTAR`.