### PR TITLE
fix memory leak

### DIFF
--- a/src/UTMConverter.cpp
+++ b/src/UTMConverter.cpp
@@ -25,6 +25,12 @@ UTMConverter::UTMConverter(UTMConversionParameters const& parameters)
     createCoTransform();
 }
 
+UTMConverter::~UTMConverter()
+{
+    delete latlon2utm;
+    delete utm2latlon;
+}
+
 void UTMConverter::setParameters(UTMConversionParameters const& parameters)
 {
     utm_zone = parameters.utm_zone;

--- a/src/UTMConverter.hpp
+++ b/src/UTMConverter.hpp
@@ -22,6 +22,8 @@ namespace gps_base
             UTMConverter();
             UTMConverter(UTMConversionParameters const& parameters);
 
+            ~UTMConverter();
+
             void setParameters(UTMConversionParameters const& parameters);
 
             UTMConversionParameters getParameters() const;


### PR DESCRIPTION
latlon2utm and utm2latlon are pointers allocated by createCoTransform but there is no destructor that deletes it.

This PR adds the missing destructor.