### PR TITLE
feat: implement a generic RTCM reassembly class

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,6 +10,7 @@
   <depend package="base/types" />
   <depend package="gdal" />
   <depend package="proj" />
+  <depend package="drivers/iodrivers_base" />
 
   <test_depend package="boost" />
 </package>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,9 @@ include_directories(${GDAL_INCLUDE_DIRS})
 link_directories(${GDAL_LIBRARY_DIRS})
 
 rock_library(gps_base
-    SOURCES UTMConverter.cpp rtcm3.cpp
-    HEADERS UTMConverter.hpp BaseTypes.hpp rtcm3.hpp
-    DEPS_PKGCONFIG base-types
+    SOURCES UTMConverter.cpp rtcm3.cpp RTCMReassembly.cpp
+    HEADERS UTMConverter.hpp BaseTypes.hpp rtcm3.hpp RTCMReassembly.hpp
+    DEPS_PKGCONFIG base-types iodrivers_base
 )
 
 target_link_libraries(gps_base ${GDAL_LIBRARIES})

--- a/src/RTCMReassembly.cpp
+++ b/src/RTCMReassembly.cpp
@@ -1,0 +1,43 @@
+#include <gps_base/RTCMReassembly.hpp>
+
+#include <gps_base/rtcm3.hpp>
+#include <iodrivers_base/Driver.hpp>
+#include <iodrivers_base/TestStream.hpp>
+
+using namespace gps_base;
+using namespace std;
+
+struct RTCMReassembly::ReassemblyDriver : public iodrivers_base::Driver {
+    int extractPacket(uint8_t const* bytes, size_t size) const {
+        return rtcm3::extractPacket(bytes, size);
+    }
+
+    ReassemblyDriver()
+        : iodrivers_base::Driver(BUFFER_SIZE) {}
+};
+
+RTCMReassembly::RTCMReassembly()
+    : mDriver(new RTCMReassembly::ReassemblyDriver()) {
+    mDriver->openURI("test://");
+}
+
+RTCMReassembly::~RTCMReassembly() {
+    delete mDriver;
+}
+
+/** Push data to be processed */
+void RTCMReassembly::push(std::vector<uint8_t> const& in_data) {
+    auto& stream = dynamic_cast<iodrivers_base::TestStream&>(*mDriver->getMainStream());
+    stream.pushDataToDriver(in_data);
+}
+
+std::vector<uint8_t> RTCMReassembly::pull() {
+    uint8_t buffer[BUFFER_SIZE];
+    try {
+        size_t size = mDriver->readPacket(buffer, BUFFER_SIZE, base::Time());
+        return vector<uint8_t>(buffer, buffer + size);
+    }
+    catch(iodrivers_base::TimeoutError&) {
+        return vector<uint8_t>();
+    }
+}

--- a/src/RTCMReassembly.hpp
+++ b/src/RTCMReassembly.hpp
@@ -1,0 +1,34 @@
+#ifndef GPS_BASE_RTCMREASSEMBLY_HPP
+#define GPS_BASE_RTCMREASSEMBLY_HPP
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace gps_base {
+    /** Reassembly of RTCM packets from a raw byte stream
+     */
+    class RTCMReassembly {
+        static constexpr int BUFFER_SIZE = 4096;
+
+        struct ReassemblyDriver;
+        ReassemblyDriver* mDriver = nullptr;
+
+    public:
+        RTCMReassembly();
+        RTCMReassembly(RTCMReassembly&) = delete;
+        ~RTCMReassembly();
+
+        /** Push data to be processed */
+        void push(std::vector<uint8_t> const& in_data);
+
+        /** Extract a single frame
+         *
+         * @return the frame's data, or an empty vector if there is no full
+         *   frame available
+         */
+        std::vector<uint8_t> pull();
+    };
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 rock_testsuite(test_suite suite.cpp
    test_UTMConverter.cpp
    test_rtcm3.cpp
+   test_RTCMReassembly.cpp
    DEPS gps_base)

--- a/test/test_RTCMReassembly.cpp
+++ b/test/test_RTCMReassembly.cpp
@@ -1,0 +1,32 @@
+#include <boost/test/unit_test.hpp>
+#include <gps_base/RTCMReassembly.hpp>
+
+#include <fstream>
+
+using namespace gps_base;
+using namespace std;
+
+const std::vector<uint8_t> VALID_RTCM =
+{
+    0xd3, 0x00, 0x13, 0x3e, 0xd0, 0x00, 0x02, 0x36,
+    0xfd, 0xb8, 0x0d, 0xde, 0x08, 0x00, 0x5b, 0x2b,
+    0xc1, 0x08, 0xa7, 0xb9, 0x8d, 0x3d, 0xd8, 0xab, 0x37
+};
+
+BOOST_AUTO_TEST_CASE(pull_extracts_a_RTCM_packet_from_the_pushed_data) {
+    RTCMReassembly reassembly;
+    reassembly.push(VALID_RTCM);
+    BOOST_TEST(reassembly.pull() == VALID_RTCM);
+    BOOST_TEST(reassembly.pull().empty() == true);
+}
+
+BOOST_AUTO_TEST_CASE(it_handles_getting_more_data_than_the_internal_driver_buffer) {
+    std::vector<uint8_t> in_data;
+    in_data.resize(4096);
+    in_data.insert(in_data.end(), VALID_RTCM.begin(), VALID_RTCM.end());
+
+    RTCMReassembly reassembly;
+    reassembly.push(in_data);
+    BOOST_TEST(reassembly.pull() == VALID_RTCM);
+    BOOST_TEST(reassembly.pull().empty() == true);
+}


### PR DESCRIPTION
It turns out that this is a functionality that's more generally needed
than I thought. The GNSS units themselves require to be sent full
RTCM messages at once if it is multiplexed with other messages, and
how messages get received is pretty varied, and often byte-oriented.